### PR TITLE
Switched to using numeric representation of status codes in translation files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ The generator will:
 
 Exceptionally Beautiful will handle any three-digit status code you throw at it. It comes with translation data for the following common errors:
 
-|         Error         | Code |
-|:---------------------:|------|
-| Forbidden             | 403  |
-| Not Found             | 404  |
-| Unprocessable Entity  | 422  |
-| Internal Server Error | 500  |
-| Bad Gateway           | 502  |
+| Code |         Error         |
+|------|:---------------------:|
+| 403  | Forbidden             |
+| 404  | Not Found             |
+| 422  | Unprocessable Entity  |
+| 500  | Internal Server Error |
+| 502  | Bad Gateway           |
 
 Any status code that is either unrecognized or missing translation data will fall back to default messaging.
 
 ## Customizing
 
-If the default controller, action, and/or layout don't suit your fancy, you can override any of them:
+If the default controller, action, and/or layout don't suit your fancy, you can override any of them in the initializer provided by the generator:
 
 ``` ruby
 ExceptionallyBeautiful.setup do |config|
@@ -46,6 +46,39 @@ ExceptionallyBeautiful.setup do |config|
   config.controller = 'exceptionally_beautiful/errors'
   config.action = 'show'
 end
+```
+
+### Error Messages
+
+You can customize and add new errors to the translation file copied over by the initializer (`config/locales/exceptionally_beautiful.en.yml`).
+
+#### I18n Gotcha
+
+Make sure that all new error codes in your translation file are prefixed with a `:`. This is needed for `I18n` translation lookups to work properly when using keys that are integers. See [this](https://github.com/svenfuchs/rails-i18n/issues/36) for more information. e.g.
+
+``` yaml
+en:
+  exceptionally_beautiful:
+    default:
+      title: "There's been an error"
+      message: "Something has gone wrong. Please try again shortly."
+    :401:
+      title: "Unauthorized"
+      message: "Leave and never come back!"
+```
+
+#### Markdown Formatting
+
+The `message` for each error can be formatted using Markdown. e.g.
+
+``` yaml
+  exceptionally_beautiful:
+    default:
+      title: "There's been an error"
+      message: |
+        Something has **gone wrong**. Please try again shortly.
+
+        Or just go [back to our home page](/)...
 ```
 
 ## Usage With `rescue_from`
@@ -60,4 +93,27 @@ class ApplicationController < ActionController::Base
     error_handler(404)
   end
 end
+```
+
+## Inspiration & Alternatives
+
+This is by no means the first library to tackle this problem. Check out these other alternatives before deciding what to use.
+
+* [Ryan Bates' Railscast](http://railscasts.com/episodes/53-handling-exceptions-revised)
+* [errship](https://github.com/logankoester/errship)
+* [error_pages_engine](https://github.com/lazylester/error_pages_engine)
+* [dynamic_error_pages](https://github.com/marcusg/dynamic_error_pages)
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Running tests
+
+```bash
+bundle exec guard
 ```

--- a/app/models/exceptionally_beautiful/error.rb
+++ b/app/models/exceptionally_beautiful/error.rb
@@ -1,10 +1,9 @@
 module ExceptionallyBeautiful
   class Error
-    attr_reader :status_code, :status
+    attr_reader :status_code
 
     def initialize(status_code)
       @status_code = status_code.to_i
-      determine_status
     end
 
     def title
@@ -17,25 +16,19 @@ module ExceptionallyBeautiful
 
     private
 
-    def determine_status
-      match = Rack::Utils::SYMBOL_TO_STATUS_CODE.detect { |k, v| v == status_code }
-      if match
-        @status = match.first
-      else
-        log('The status code passed in is not recognized by Rack.')
-        @status = 'default'
-      end
-    end
-
     def pretty_error_translation(key)
-      I18n.t(key, :scope => ExceptionallyBeautiful.translation_scope(status), :raise => true)
+      I18n.t(key, :scope => translation_scope, :raise => true)
     rescue I18n::MissingTranslationData
-      log("Translation missing: #{ExceptionallyBeautiful.translation_scope(status)}.#{key}. Falling back to defaults.")
+      log("Translation missing: #{translation_scope}.#{key}. Falling back to defaults.")
       I18n.t(key, :scope => ExceptionallyBeautiful.translation_scope('default'))
     end
 
     def log(message)
       ExceptionallyBeautiful.log(message)
+    end
+
+    def translation_scope
+      ExceptionallyBeautiful.translation_scope(status_code)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,18 +3,18 @@ en:
     default:
       title: "There's been an error"
       message: "Something has gone wrong. Please try again shortly."
-    forbidden:
+    :403:
       title: "Sorry, but you don't have access."
       message: "Please try a different request."
-    not_found:
+    :404:
       title: "The page you requested could not be found."
       message: "It may have moved."
-    unprocessable_entity:
+    :422:
       title: "The change you requested was rejected."
       message: "Please try a different request."
-    internal_server_error:
+    :500:
       title: "A fatal error has occurred."
       message: "Please try a different request."
-    bad_gateway:
+    :502:
       title: "The site is currently unavailable."
       message: "Please try again in a few moments!"

--- a/lib/exceptionally_beautiful.rb
+++ b/lib/exceptionally_beautiful.rb
@@ -20,8 +20,8 @@ module ExceptionallyBeautiful
     yield self
   end
 
-  def self.translation_scope(error_code)
-    [translation_namespace, error_code].join('.')
+  def self.translation_scope(status_code)
+    [translation_namespace, status_code].join('.')
   end
 
   def self.log(message)


### PR DESCRIPTION
This is instead of using Rack's weird, underscored string representations. The gotcha here is that the keys must be prefixed with a : to symbolize it, thus allowing it to work with I18n's lookup system.

Updated Readme accordingly.
