### PR TITLE
Allow application routes to work within custom layouts.

### DIFF
--- a/app/controllers/exceptionally_beautiful/application_controller.rb
+++ b/app/controllers/exceptionally_beautiful/application_controller.rb
@@ -1,4 +1,6 @@
 module ExceptionallyBeautiful
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ::ApplicationController
+    helper Rails.application.routes.url_helpers
+    helper ExceptionallyBeautiful::RenderHelper
   end
 end


### PR DESCRIPTION
- Changed `ExceptionallyBeautiful::ApplicationController` to inherit from `::ApplicationController`.
- Include `Rails.application.routes.url_helpers` as a helper in our `ExceptionallyBeautiful::ApplicationController` so named route helpers are available in views and layouts rendered by our controller.
